### PR TITLE
Use test helpers for wallet creation in ownership tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@ jobs:
       - setup_remote_docker
 
       - run: |
-          docker create -v /src --name source alpine /bin/true
-          docker cp . source:/src
+          docker create -v /src/tupelo --name source alpine /bin/true
+          docker cp . source:/src/tupelo
 
       # TODO: Figure out node.js caching here
 

--- a/test/data.js
+++ b/test/data.js
@@ -1,7 +1,6 @@
 const helpers = require("./helpers");
 const assert = require("assert");
 const Tagged = require("cbor/lib/tagged");
-const Tupelo = require("../lib/tupelo");
 const itRequires = helpers.itRequires
 
 describe("setting and retrieving data", function() {

--- a/test/ownership.js
+++ b/test/ownership.js
@@ -1,6 +1,5 @@
 const assert = require("assert");
-const Tupelo = require("../lib/tupelo");
-const TUPELO_HOST = process.env.TUPELO_RPC_HOST || 'localhost:50051'
+const helpers = require("./helpers");
 
 // TODO: Remove the "oldResult" tests once resolveData support is released.
 
@@ -8,24 +7,9 @@ describe("ownership transfer", function () {
   this.timeout(30000);
   
   it("can export and import", async () => {
-    const alice = Tupelo.connect(TUPELO_HOST, {
-      walletName: "alice-test",
-      passPhrase: "test",
-    });
-    // TODO: clear RPC server state between tests automatically
-    await alice.register();
-    const {keyAddr: aliceKey,} = await alice.generateKey();
-    const {chainId,} = await alice.createChainTree(aliceKey);
-    
-    const bob = Tupelo.connect(TUPELO_HOST, {
-      walletName: "bob-test",
-      passPhrase: "test",
-    });
-    // TODO: clear RPC server state between tests automatically
-    await bob.register();
-    const {keyAddr: bobKey,} = await bob.generateKey();
-    assert.strictEqual(bobKey.length, 42);
-    
+    let {wallet: alice, walletKey: aliceKey, chainId: chainId} = await helpers.createWalletWithChain();
+    let {wallet: bob, walletKey: bobKey, chainId: bobChainId} = await helpers.createWalletWithChain();
+        
     let resp = await alice.setData(chainId, aliceKey, "path/to/here", "hi");
     assert.notEqual(resp.tip, null);
     
@@ -41,22 +25,8 @@ describe("ownership transfer", function () {
   });
   
   it("can do a real transfer from alice to bob", async () => {
-    const alice = Tupelo.connect(TUPELO_HOST, {
-      walletName: "alice-test",
-      passPhrase: "test",
-    });
-    // TODO: clear RPC server state between tests automatically
-    // await alice.register();
-    const {keyAddr: aliceKey,} = await alice.generateKey();
-    let {chainId,} = await alice.createChainTree(aliceKey);
-    
-    const bob = Tupelo.connect(TUPELO_HOST, {
-      walletName: "bob-test",
-      passPhrase: "test",
-    });
-    // TODO: clear RPC server state between tests automatically
-    // await bob.register();
-    const {keyAddr: bobKey,} = await bob.generateKey();
+    let {wallet: alice, walletKey: aliceKey, chainId: chainId} = await helpers.createWalletWithChain();
+    let {wallet: bob, walletKey: bobKey, chainId: bobChainId} = await helpers.createWalletWithChain();
     
     for (let i = 0; i < 5; i++) {
       const resp = await alice.setData(chainId, aliceKey, "path/to/" + i.toString(),


### PR DESCRIPTION
This should fix these tests when run against long-running test networks
(as we now do in integration tests & CI).