### PR TITLE
Dag helpers from base64

### DIFF
--- a/lib/tupelo.js
+++ b/lib/tupelo.js
@@ -278,7 +278,7 @@ class TupeloClient {
    */
 
   /**
-   * Get a Base58 serialized chain tree Export
+   * Get a Base64 serialized chain tree Export
    *
    * @param {string} chainId - The ID of the chain tree to be exported
    *
@@ -295,14 +295,14 @@ class TupeloClient {
   }
   /**
    * @typedef {Object} ExportChainTreeResponse
-   * @property {SerializedChainTree} chainTree - The serialized chain tree
+   * @property {string} chainTree - The base64 serialized chain tree
    */
 
 
   /**
    * Import a serialized chain tree and save it to the wallet.
    *
-   * @param {SerializedChaintree} chainTree - Serialized chain tree to import
+   * @param {string} chainTree - The base64 serialized chain tree to import
    * @param {StorageAdapterConfig} [storageAdapter] - Storage configuration for the chain tree
    *
    *
@@ -626,20 +626,6 @@ class TupeloClient {
    * @typedef {Object} StorageAdapterConfig
    * @property {StorageAdapterConfigForBadger} badger - Configure and use the badger storage adapter
    * @property {StorageAdapterConfigForIpld} ipld - Configure and use the ipld storage adapter
-   */
-
-  /**
-   * @typedef {Object} SerializedChainTree
-   * @property {string} tip - Hash of the latest root tree node.
-   * @property {string[]} dag - base58 encoded string array representing the chain tree dag nodes
-   * @property {Map<String, SerializedSignature>} signatures - Map of serialized signatures
-   */
-
-  /**
-   * @typedef {Object} SerializedSignature
-   * @property {boolean[]} signers - Array indicating which signers have signed
-   * @property {string} signature - base58 encoded signature
-   * @property {string} type - Signature type
    */
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -358,11 +358,18 @@
       "integrity": "sha512-hKTxeYt3AIzIG45epJHv8xJYSF0ktp7nZgFsqi5cPzoL3T8qKMPeUlqydORy6j3NWZvRDANx30PjpTmGho69Gw==",
       "dev": true,
       "requires": {
-        "bignumber.js": "^8.0.1",
+        "bignumber.js": "^9.0.0",
         "commander": "^2.15.0",
         "ieee754": "^1.1.8",
         "iso-url": "~0.4.4",
         "json-text-sequence": "~0.1.0"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+          "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+        }
       }
     },
     "brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "@grpc/grpc-js": "^0.4.3",
     "cbor": "^4.1.5",
     "cids": "^0.7.1",
+    "ipfs-block": "^0.8.1",
+    "ipld-dag-cbor": "^0.15.0",
     "tupelo-messages": "0.0.1-rc6"
   },
   "devDependencies": {

--- a/src/@types/cids/index.d.ts
+++ b/src/@types/cids/index.d.ts
@@ -5,8 +5,8 @@ declare module 'cids' {
 		multihash: Buffer
 	}
 
-	export class CID {
-		constructor(version: number, codec: string, multihash: Buffer)
+	export default class CID {
+		constructor(version: string|number|Buffer|CID, codec?: string, multihash?: Buffer, multibaseName?: string)
 		static isCID(other: any): boolean
 		static validateCID(other: any): void
 		codec: string

--- a/test/chaintree/dag/dag.js
+++ b/test/chaintree/dag/dag.js
@@ -7,7 +7,7 @@ const Ipld = require('ipld');
 const IpfsRepo = require('ipfs-repo');
 const IpfsBlockService = require('ipfs-block-service');
 const MemoryDatastore = require('interface-datastore').MemoryDatastore;
-
+const CID = require("cids");
 
 const testIpld = () => {
   return new Promise((resolve, reject) => {
@@ -127,5 +127,50 @@ describe("basic dag operations", function() {
       assert.deepStrictEqual(resolved, c.expect) 
     }
   });
+
+  it("can import a serialized chain tree paths", async ()=> {
+    const ipld = await testIpld()
+    const serializedTreeWithChildFooBar = "Ci6hY2VuZNgqWCUAAXESIBfASQ07dBPoXAazp2U0RBHjqQAwuH3JqG1fe3Ljed1kCsoEo2ZoZWlnaHQAZ2hlYWRlcnOhanNpZ25hdHVyZXOheCoweDZBNTRkRTQwN2U1OEZDZDNkQjg4YmJiMDcxRTQ5QUJhZTM0MjdmRkWtZHR5cGVpc2VjcDI1NmsxZHZpZXcAZWN5Y2xlAGZoZWlnaHQAZm5ld1RpcPZnc2lnbmVyc/Zob2JqZWN0SWT2aXNpZ25hdHVyZVhBoicWQcTICGNP473V8VadpfHTMQ2Q/zgbif8K2GxIeEhyZvbcCT9PMezMxQakABQDCiDVglNtSVdfIvOVDYiIEQFrcHJldmlvdXNUaXD2bXRyYW5zYWN0aW9uSWT2bXhYWF9zaXplY2FjaGUAcHhYWF91bnJlY29nbml6ZWT2dHhYWF9Ob1Vua2V5ZWRMaXRlcmFsoGx0cmFuc2FjdGlvbnOBq2R0eXBlAWxzdGFrZVBheWxvYWT2bXhYWF9zaXplY2FjaGUAbnNldERhdGFQYXlsb2FkpWRwYXRoaWNoaWxkL2Zvb2V2YWx1ZURjYmFybXhYWF9zaXplY2FjaGUAcHhYWF91bnJlY29nbml6ZWT2dHhYWF9Ob1Vua2V5ZWRMaXRlcmFsoHBtaW50VG9rZW5QYXlsb2Fk9nBzZW5kVG9rZW5QYXlsb2Fk9nB4WFhfdW5yZWNvZ25pemVk9nNyZWNlaXZlVG9rZW5QYXlsb2Fk9nNzZXRPd25lcnNoaXBQYXlsb2Fk9nR4WFhfTm9VbmtleWVkTGl0ZXJhbKB1ZXN0YWJsaXNoVG9rZW5QYXlsb2Fk9govoWRkYXRh2CpYJQABcRIgAJJfMOxCnTkD/LJTadoqcUt9Qnk5UiWvsRF4VMwjw+gKMKFlY2hpbGTYKlglAAFxEiArA6ZJ1s4JPipqkKtGOPiW1DYqf7CTrEovKqaIYQODvAoJoWNmb29jYmFyCqABpGJpZHg1ZGlkOnR1cGVsbzoweDZBNTRkRTQwN2U1OEZDZDNkQjg4YmJiMDcxRTQ5QUJhZTM0MjdmRkVkdHJlZdgqWCUAAXESIIz4+0hAumQwHlBJ5EceZ3ppIOb5SLoUsaZPvkz6vAUKZWNoYWlu2CpYJQABcRIgYJAY9cZu4rRldrVh0W91RYnqJNDtwARUBcu20LQorzxmaGVpZ2h0ABKDAgoSbG9jYWwgbm90YXJ5IGdyb3VwEuwBCgMBAAESQDkhFHNng5iOl9ZPg+N1GyExUDuZ/eifxJKg87SHoGtzXUi2HZ63WYMyrxH32U6N1h7do8z0NMgGedY9n6vOgm0iNWRpZDp0dXBlbG86MHg2QTU0ZEU0MDdlNThGQ2QzZEI4OGJiYjA3MUU0OUFCYWUzNDI3ZkZFKiQBcRIg2fAZFPQ81y1B1ji+3loh28kmwqtzeVF8j2n/4vxnqJ4yJAFxEiAQMh3Z9hZtKoCvkCb963T0TWP02zNAabUoL9TwyMOMPVIgoTRGeTawe3kBr7ziW7S+s4K8rNRs0ZuNViDbNbk6HAAaMXpkcHVBbVdmTDJHdXVKM0M5YmFDejZvajltQzdhVm53b1JKZlZtYlJEcWEzZm9qcms="
+    const testDag = await new dag.DagFromBase64(serializedTreeWithChildFooBar, ipld)
+
+    const cases = [
+      {
+        test: ["child", "foo"],
+        expect: {
+          remainderPath: [],
+          value: "bar"
+        }
+      }, {
+        test: ["child"],
+        expect: {
+          remainderPath: [],
+          value: {"foo": "bar"}
+        }
+      }, {
+        test: [],
+        expect: {
+          remainderPath: [],
+          value: {"child": new CID("bafyreiblaotetvwobe7cu2uqvnddr6ew2q3cu75qsoweulzku2egca4dxq")}
+        }
+      }, {
+        test: ["child", "other"],
+        expect: {
+          remainderPath: ["other"],
+          value: null
+        }
+      }, {
+        test: ["child", "foo", "notAKey"],
+        expect: {
+          remainderPath: ["foo", "notAKey"],
+          value: null
+        }
+      }
+    ]
+
+    for (let c of cases) {
+      let resolved = await testDag.resolve(["tree", "data"].concat(c.test))
+      assert.deepStrictEqual(resolved, c.expect)
+    }
+  })
 
 })


### PR DESCRIPTION
This adds the ability to build a `Dag` from a base64 encoded signed chaintree. This works for the near term, but the actual storage of the nodes is a bit icky at the moment due to ipld interface (more below). That being said, I believe this is fine for now given we are still investigating the wasm path.

Also I believe the docs were incorrect for `ExportChainTreeResponse`, so fixed that as well.

On the `IpldResolver` interface, there isn't a way to pass an already cbor-encoded blob or a block into `put`. In addition, the `put` method also forces passing in the codec from the caller, which seems like an unnecessary interface to implement for us because we always want cbor. It does look like you can overwrite the format encoding delegation with a bit of work, so if we stick with this approach I would recommend we have a wrapper around`IPLDResolver` that would do that overwrite and simplify methods.